### PR TITLE
fix: dynamic import in webpack by using whatwg-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "apollo-link": "^1.2.1",
-    "cross-fetch": "2.0.0",
-    "dataloader": "^1.4.0"
+    "dataloader": "^1.4.0",
+    "whatwg-fetch": "^2.0.4"
   }
 }

--- a/src/BatchedGraphQLClient.ts
+++ b/src/BatchedGraphQLClient.ts
@@ -1,5 +1,5 @@
 import { Options, Variables } from './types'
-import 'cross-fetch/polyfill'
+import 'whatwg-fetch'
 import * as DataLoader from 'dataloader'
 import { ClientError } from './ClientError'
 import { ClientOptions } from '.'


### PR DESCRIPTION
Use `whatwg-fetch` in place of `cross-fetch` to avoid a dynamic import. 